### PR TITLE
Batchifier First Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,327 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+*.gem
+
+
+# Created by https://www.gitignore.io/api/ruby,rubymine,rails,emacs,vim,sublimetext,osx,macos,linux,windows
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### OSX ###
+
+# Icon must end with two \r
+
+
+# Thumbnails
+
+# Files that might appear in the root of a volume
+
+# Directories potentially created on remote AFP share
+
+### Rails ###
+*.rbc
+capybara-*.html
+.rspec
+/log
+/tmp
+/db/*.sqlite3
+/db/*.sqlite3-journal
+/public/system
+/coverage/
+/spec/tmp
+**.orig
+rerun.txt
+pickle-email-*.html
+
+# TODO Comment out this rule if you are OK with secrets being uploaded to the repo
+config/initializers/secret_token.rb
+
+# Only include if you have production secrets in this file, which is no longer a Rails default
+# config/secrets.yml
+
+# dotenv
+# TODO Comment out this rule if environment variables can be committed
+.env
+
+## Environment normalization:
+/.bundle
+/vendor/bundle
+
+# these should all be checked in to normalize the environment:
+# Gemfile.lock, .ruby-version, .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# if using bower-rails ignore default bower_components path bower.json files
+/vendor/assets/bower_components
+*.bowerrc
+bower.json
+
+# Ignore pow environment settings
+.powenv
+
+# Ignore Byebug command history file.
+.byebug_history
+
+### Ruby ###
+*.gem
+/.config
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+
+### RubyMine ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### RubyMine Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+### SublimeText ###
+# cache files for sublime text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### Vim ###
+# swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+# auto-generated tag files
+tags
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/ruby,rubymine,rails,emacs,vim,sublimetext,osx,macos,linux,windows

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in wor-batchifier.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,83 @@
+PATH
+  remote: .
+  specs:
+    wor-batchifier (0.0.1)
+      httparty (~> 0.13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    byebug (9.1.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    docile (1.3.1)
+    hashdiff (0.3.8)
+    httparty (0.16.4)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    jaro_winkler (1.5.2)
+    json (2.1.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_xml (0.6.0)
+    parallel (1.13.0)
+    parser (2.6.0.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    public_suffix (3.0.3)
+    rainbow (3.0.0)
+    rake (10.5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rubocop (0.63.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
+    safe_yaml (1.0.4)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    unicode-display_width (1.4.1)
+    webmock (3.5.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  byebug (~> 9.0)
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  rubocop (~> 0.47)
+  simplecov
+  webmock
+  wor-batchifier!
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# wor-batchifier
+# Wolox on Rails - Batchifier
+[![Gem Version](https://badge.fury.io/rb/wor-batchifier.svg)](https://badge.fury.io/rb/wor-batchifier)
+[![Dependency Status](https://gemnasium.com/badges/github.com/Wolox/wor-batchifier.svg)](https://gemnasium.com/github.com/Wolox/wor-batchifier)
+[![Build Status](https://travis-ci.org/Wolox/wor-batchifier.svg)](https://travis-ci.org/Wolox/wor-batchifier)
+[![Code Climate](https://codeclimate.com/github/Wolox/wor-batchifier/badges/gpa.svg)](https://codeclimate.com/github/Wolox/wor-authentication)
+[![Test Coverage](https://codeclimate.com/github/Wolox/wor-batchifier/badges/coverage.svg)](https://codeclimate.com/github/Wolox/wor-batchifier/coverage)
+
+Gem for batchifying your requests.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'wor-batchifier'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install wor-batchifier
+
+## Usage
+
+### Basic configuration
+
+
+
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Run rubocop lint (`rubocop -R --format simple`)
+5. Run rspec tests (`bundle exec rspec`)
+6. Push your branch (`git push origin my-new-feature`)
+7. Create a new Pull Request
+
+## About ##
+
+This project is maintained by [Diego Raffo](https://github.com/enanodr) along with [Pedro Jara](https://github.com/redwarewolf) and it was written by [Wolox](http://www.wolox.com.ar).
+![Wolox](https://raw.githubusercontent.com/Wolox/press-kit/master/logos/logo_banner.png)
+
+## License
+
+**wor-batchifier** is available under the MIT [license](https://raw.githubusercontent.com/Wolox/wor-batchifier/master/LICENSE.md).
+
+    Copyright (c) 2017 Wolox
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Climate](https://codeclimate.com/github/Wolox/wor-batchifier/badges/gpa.svg)](https://codeclimate.com/github/Wolox/wor-authentication)
 [![Test Coverage](https://codeclimate.com/github/Wolox/wor-batchifier/badges/coverage.svg)](https://codeclimate.com/github/Wolox/wor-batchifier/coverage)
 
-Gem for batchifying your requests.
+Gem that allows you to easily divide requests that send a lot of information into several requests with smaller chunks of data, taking care of the response from each one and providing it joint together based on different strategies for parsing said response.
 
 ## Installation
 
@@ -25,10 +25,45 @@ Or install it yourself as:
 
 ## Usage
 
-### Basic configuration
+### Basic use:
 
+The first step is to define a parent controller from which all other controllers will have to extend to have access to the batchifier's methods. So, let's do that in our `ApplicationController.rb`:
 
+```ruby
+class ApplicationController < ActionController::Base
+  include Wor::Batchifier
+end
+```
 
+You can also include the batchifier just in the controllers you intend to use it in.
+
+The final step, is to find any request you wish to perform with smaller chunks of data and utilize the batchifier's methods to divide it into smaller tasks.
+
+For example, let's pretend we have an endpoint called bulk_request that communicates with a third API and sends a lot of information to be utilized.
+
+```ruby
+def bulk_request
+  ThirdAPI.bulk_request(params[:information])
+end
+```
+
+Now we will partition that request into chunks using the batchifier:
+
+```ruby
+def bulk_request
+  execute_in_batches(params[:information], batch_size: 100, strategy: :add) do |chunks|
+    ThirdAPI.bulk_request(chunks)
+  end
+end
+```
+
+The batchifier will take three parameters, the first one being the information that needs to be partitioned, then the batch_size we wish to utilize and finally the strategy that will be implemented on the response of each batch.
+
+### Available strategies
+
+- Add: For each request, it joins together each response no matter the result.
+- Maintain-Unique: It will only add the results that are not present already in the response.
+- No-Response: It will not provide any response whatsoever.
 
 ## Contributing
 
@@ -68,4 +103,3 @@ This project is maintained by [Diego Raffo](https://github.com/enanodr) along wi
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/wor/batchifier.rb
+++ b/lib/wor/batchifier.rb
@@ -14,7 +14,7 @@ module Wor
       end
     end
 
-    protected
+    private
 
     def merge(response, rec, strategy)
       return rec.merge(response) { |_, v1, v2| v1 + v2 } if strategy == :add

--- a/lib/wor/batchifier.rb
+++ b/lib/wor/batchifier.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module Wor
+  module Batchifier
+    class WrongStrategy < StandardError; end
+
+    # This module exports the function execute_in_batches, that needs a collections and
+    # => optionaly a batch_size and a merge strategy. It will slice the collection and
+    # => apply the given block to all chunks and merge the results. It expects the responses
+    # => to be Hash. It can ignore them if the given stragegy is no_response
+    def execute_in_batches(collection, batch_size: 100, strategy: :add)
+      collection.each_slice(batch_size).to_a.inject({}) do |rec, chunk|
+        response = yield(chunk)
+        merge(response, rec, strategy)
+      end
+    end
+
+    protected
+
+    def merge(response, rec, strategy)
+      return rec.merge(response) { |_, v1, v2| v1 + v2 } if strategy == :add
+      return rec.merge(response) { |_, v1, _| v1 } if strategy == :maintain_unique
+      return {} if strategy == :no_response
+      raise WrongStrategy
+    end
+  end
+end

--- a/lib/wor/batchifier/version.rb
+++ b/lib/wor/batchifier/version.rb
@@ -1,0 +1,6 @@
+
+module Wor
+  module Batchifier
+    VERSION = '0.0.1'.freeze
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+# Configure Rails Environment
+ENV["RAILS_ENV"] = "test"
+
+require 'simplecov'
+SimpleCov.start
+
+require 'byebug'
+require 'wor/batchifier'
+require 'webmock/rspec'
+require 'httparty'

--- a/spec/wor/batchifier_spec.rb
+++ b/spec/wor/batchifier_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+require 'spec_helper'
+include Wor::Batchifier
+
+describe Wor::Batchifier do
+  describe 'execute_in_batches' do
+    context 'When executing batch requests' do
+      let(:ids) { Array.new(100) { rand(1...9) } }
+      let(:body) do
+        {
+          key1: [1], key2: [2], key3: [3], key4: [4], key5: [5]
+        }.to_json
+      end
+
+      before do
+        stub_request(:post, /.*some_example_request.*/)
+          .to_return(status: 200, body: body, headers: {})
+      end
+
+      context 'with add strategy' do
+        let(:expected_response) do
+          {
+            'key1' => [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            'key2' => [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+            'key3' => [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            'key4' => [4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+            'key5' => [5, 5, 5, 5, 5, 5, 5, 5, 5, 5]
+          }
+        end
+
+        let(:batchified_request) do
+          execute_in_batches(ids, batch_size: 10) do |chunk|
+            resp = HTTParty.post('https://some_example_request.com', body: { ids: chunk })
+            JSON.parse resp.body
+          end
+        end
+
+        it 'it makes a request per batch' do
+          batchified_request
+          expect(a_request(:post, 'https://some_example_request.com'))
+            .to have_been_made.times(10)
+        end
+
+        it 'adds the responses of every batch' do
+          expect(batchified_request).to eq(expected_response)
+        end
+      end
+
+      context 'with unique strategy' do
+        let(:expected_response) do
+          {
+            'key1' => [1],
+            'key2' => [2],
+            'key3' => [3],
+            'key4' => [4],
+            'key5' => [5]
+          }
+        end
+        let(:batchified_request) do
+          execute_in_batches(ids, batch_size: 10, strategy: :maintain_unique) do |chunk|
+            resp = HTTParty.post('https://some_example_request.com', body: { ids: chunk })
+            JSON.parse resp.body
+          end
+        end
+        it 'it makes a request per batch' do
+          batchified_request
+          expect(a_request(:post, 'https://some_example_request.com'))
+            .to have_been_made.times(10)
+        end
+
+        it 'maintains the unique reponse' do
+          expect(batchified_request).to eq(expected_response)
+        end
+      end
+      context 'with no response strategy' do
+        let(:expected_response) { {} }
+        let(:batchified_request) do
+          execute_in_batches(ids, batch_size: 10, strategy: :no_response) do |chunk|
+            resp = HTTParty.post('https://some_example_request.com', body: { ids: chunk })
+            JSON.parse resp.body
+          end
+        end
+        it 'it makes a request per batch' do
+          batchified_request
+          expect(a_request(:post, 'https://some_example_request.com'))
+            .to have_been_made.times(10)
+        end
+
+        it 'returns empty response' do
+          expect(batchified_request).to eq(expected_response)
+        end
+      end
+      context 'with no wrong strategy' do
+        let(:batchified_request) do
+          execute_in_batches(ids, batch_size: 10, strategy: :wrong_strategy) do |chunk|
+            resp = HTTParty.post('https://some_example_request.com', body: { ids: chunk })
+            JSON.parse resp.body
+          end
+        end
+
+        it 'raises wrong strategy exception' do
+          expect { batchified_request }.to raise_error(Wor::Batchifier::WrongStrategy)
+        end
+      end
+    end
+  end
+end

--- a/wor-batchifier.gemspec
+++ b/wor-batchifier.gemspec
@@ -1,0 +1,33 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'wor/batchifier/version'
+require 'date'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'wor-batchifier'
+  spec.version       = Wor::Batchifier::VERSION
+  spec.platform      = Gem::Platform::RUBY
+  spec.date          = Date.today
+  spec.authors       = ['enanodr', 'redwarewolf']
+  spec.email         = ['diego.raffo@wolox.com.ar', 'pedro.jara@wolox.com.ar']
+
+  spec.summary       = 'Easily batchify your requests!.'
+  spec.description   = 'Gem to batchify your requests.'
+  spec.homepage      = 'https://github.com/Wolox/wor-batchifier'
+  spec.license       = 'MIT'
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec)/}) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec)/})
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'httparty', '~> 0.13'
+
+  spec.add_development_dependency 'byebug', '~> 9.0'
+  spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'webmock'
+end


### PR DESCRIPTION
### Batchifier - First Version 

Implemented a simple version for a requests batchifier that will allow you to easily divide a big request into smaller parts (batches that can be configured) as to not over burden your APIs. The batchifier will take care of providing the results of all the batches according to pre-defined strategies that you can choose from.

## Strategies

- Add: For each request, it unites together each response no matter the result
- Maintain-Unique: It will only add the results that are not present already in the response
- No-Response: It will not provide any response whatsoever

## ToDo - Future Versions

- As to further upgrade the gem's usability, it is intended for the user of the gem to be able to add their own custom strategies either through a configuration file or during processing time.
- More tests to fully cover the gem's code and uses need to be added and implemented.

